### PR TITLE
Fix syntax change.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "google_secret_manager_secret" "managed_secret" {
   secret_id = "${var.prefix}${keys(var.secrets)[count.index]}"
   
   replication {
-    automatic = true
+    auto {}
   }
 }
 


### PR DESCRIPTION
The 'automatic = true' option here has been changed to auto{} in the schema. This is breaking our cloud-infra Jenkins pipeline.

https://build.vio.sh/blue/organizations/jenkins/vapor-ware%2Fcloud-infra/detail/PR-1002/7/pipeline/420/